### PR TITLE
Stub all request methods instead of just abort and setTimeout

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -19,6 +19,23 @@ var http = require('http');
 
 var playbackHits = true;
 var recordMisses = true;
+var requestMethodsToStub = [
+  'abort',
+  'addTrailers',
+  'destroy',
+  'flush',
+  'flushHeaders',
+  'getHeader',
+  'getHeaderNames',
+  'getHeaders',
+  'hasHeader',
+  'onSocket',
+  'removeHeader',
+  'setHeader',
+  'setNoDelay',
+  'setSocketKeepAlive',
+  'setTimeout'
+];
 
 module.exports.configure = function(mode) {
   switch (mode) {
@@ -103,8 +120,7 @@ module.exports.isEnabled = function isEnabled() {
     var reqBody = [];
     var debug = replayerUtil.shouldFindMatchingFixtures();
 
-    var req = new EventEmitter();
-    req.setTimeout = req.abort = function() {};
+    var req = stubMethods(new EventEmitter());
 
     req.write = function(chunk) {
       reqBody.push(chunk);
@@ -349,6 +365,14 @@ module.exports.isEnabled = function isEnabled() {
     return req;
   };
 });
+
+function stubMethods(req) {
+  requestMethodsToStub.forEach(function(method) {
+    req[method] = function() {};
+  });
+
+  return req;
+}
 
 function writeRequestFile(requestData, filename) {
   fs.writeFileSync(filename + '.request',


### PR DESCRIPTION
I've been getting errors about `setNoDelay`, `setSocketKeepAlive` and some other `http.request` methods being undefined when trying to record requests made with the official elasticsearch client. I thought it might be a good idea to stub more of the `http.request` methods, even the obscure ones.