### PR TITLE
Cause tests to fail if examples fail

### DIFF
--- a/examples/run-all-examples.sh
+++ b/examples/run-all-examples.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+set -e
 G=`printf "\033[1;32m"`
 N=`printf "\033[0m"`
 


### PR DESCRIPTION
Errors during examples now cause the run-all-examples.sh script
to fail with an exit code instead of just printing the error and
finishing with success.

We need this to catch problems in CI.