### PR TITLE
Add support for gzip/deflate encoded responses

### DIFF
--- a/examples/compressed.js
+++ b/examples/compressed.js
@@ -1,0 +1,115 @@
+var http = require('http');
+var request = require('request');
+var _ = require('lodash');
+var step = require('step');
+var zlib = require('zlib');
+require('should');
+var common = require('./common');
+
+common.ensureNonCacheMode('compressed.js');
+
+require('..');
+
+// -- TEST SERVER --------------------------------------------------------------
+
+// 1. Returns a gzip compressed string
+
+var httpServer = http
+  .createServer(function(req, res) {
+    var encoding = req.headers['accept-encoding'] || 'gzip';
+    var headers = {
+      'content-type': 'text/plain',
+      'content-encoding': req.headers['accept-encoding'],
+    };
+    
+    var body = '';
+    if (encoding === 'gzip') {
+      body = zlib.gzipSync(new Buffer('hello, gzip'));
+    } else {
+      body = zlib.deflateSync(new Buffer('hello, deflate'));
+    }
+
+    // simulate server latency
+    setTimeout(function() {
+      res.writeHead(200, headers);
+      res.end(body);
+    }, 500);
+  })
+  .listen(1337, '0.0.0.0');
+
+// -- HTTP REQUEST -------------------------------------------------------------
+
+function makeGzipHttpRequest(next) {
+  var start = Date.now();
+
+  request(
+    {
+      url: 'http://localhost:1337/gzip',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip',
+      },
+    },
+    function(err, data, body) {
+      var time = Date.now() - start;
+
+      console.log('GZIP COMPRESSION:');
+      console.log('  status:', data.statusCode);
+      console.log('  body  :', body);
+      console.log('  time  :', time);
+
+      common.verify(function() {
+        data.headers.should.not.have.property('content-encoding');
+        body.should.equal('hello, gzip');
+      });
+
+      console.log();
+
+      next();
+    }
+  );
+}
+
+function makeDeflateHttpRequest(next) {
+  var start = Date.now();
+
+  request(
+    {
+      url: 'http://localhost:1337/deflate',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'deflate',
+      },
+    },
+    function(err, data, body) {
+      var time = Date.now() - start;
+
+      console.log('DEFLATE COMPRESSION:');
+      console.log('  status:', data.statusCode);
+      console.log('  body  :', body);
+      console.log('  time  :', time);
+
+      common.verify(function() {
+        data.headers.should.not.have.property('content-encoding');
+        body.should.equal('hello, deflate');
+      });
+
+      console.log();
+
+      next();
+    }
+  );
+}
+
+// -- RUN EVERYTHING -----------------------------------------------------------
+
+step(
+  function() {
+    setTimeout(this, 100);
+  }, // let the server start up
+  function() {
+    makeGzipHttpRequest(this);
+    makeDeflateHttpRequest(this);
+  },
+  _.bind(httpServer.close, httpServer)
+);

--- a/examples/compressed.js
+++ b/examples/compressed.js
@@ -22,76 +22,37 @@ var httpServer = http
       'content-encoding': req.headers['accept-encoding'],
     };
     
-    var body = '';
-    if (encoding === 'gzip') {
-      body = zlib.gzipSync(new Buffer('hello, gzip'));
-    } else {
-      body = zlib.deflateSync(new Buffer('hello, deflate'));
-    }
+    var body = zlib[encoding + 'Sync'](new Buffer('hello, ' + encoding));
 
-    // simulate server latency
-    setTimeout(function() {
-      res.writeHead(200, headers);
-      res.end(body);
-    }, 500);
+    res.writeHead(200, headers);
+    res.end(body);
   })
   .listen(1337, '0.0.0.0');
 
 // -- HTTP REQUEST -------------------------------------------------------------
 
-function makeGzipHttpRequest(next) {
+function makeHttpRequest(encoding, next) {
   var start = Date.now();
 
   request(
     {
-      url: 'http://localhost:1337/gzip',
+      url: 'http://localhost:1337/' + encoding,
       method: 'GET',
       headers: {
-        'accept-encoding': 'gzip',
+        'accept-encoding': encoding,
       },
     },
     function(err, data, body) {
       var time = Date.now() - start;
 
-      console.log('GZIP COMPRESSION:');
+      console.log(encoding.toUpperCase() + ' COMPRESSION:');
       console.log('  status:', data.statusCode);
       console.log('  body  :', body);
       console.log('  time  :', time);
 
       common.verify(function() {
         data.headers.should.not.have.property('content-encoding');
-        body.should.equal('hello, gzip');
-      });
-
-      console.log();
-
-      next();
-    }
-  );
-}
-
-function makeDeflateHttpRequest(next) {
-  var start = Date.now();
-
-  request(
-    {
-      url: 'http://localhost:1337/deflate',
-      method: 'GET',
-      headers: {
-        'accept-encoding': 'deflate',
-      },
-    },
-    function(err, data, body) {
-      var time = Date.now() - start;
-
-      console.log('DEFLATE COMPRESSION:');
-      console.log('  status:', data.statusCode);
-      console.log('  body  :', body);
-      console.log('  time  :', time);
-
-      common.verify(function() {
-        data.headers.should.not.have.property('content-encoding');
-        body.should.equal('hello, deflate');
+        body.should.equal('hello, ' + encoding);
       });
 
       console.log();
@@ -107,9 +68,7 @@ step(
   function() {
     setTimeout(this, 100);
   }, // let the server start up
-  function() {
-    makeGzipHttpRequest(this);
-    makeDeflateHttpRequest(this);
-  },
+  function() { makeHttpRequest('gzip', this); },
+  function() { makeHttpRequest('deflate', this); },
   _.bind(httpServer.close, httpServer)
 );

--- a/examples/run-all-examples.sh
+++ b/examples/run-all-examples.sh
@@ -81,3 +81,8 @@ start_test 'substitute secrets'
 rm -r fixtures/
 VCR_MODE=record   node examples/substitutions
 VCR_MODE=playback node examples/substitutions
+
+start_test 'handle compressed responses'
+rm -r fixtures/
+VCR_MODE=record   node examples/compressed
+VCR_MODE=playback node examples/compressed

--- a/src/cache.js
+++ b/src/cache.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 var fs = require('fs');
+var zlib = require('zlib');
 var replayerUtil = require('./util');
 var EventEmitter = require('events').EventEmitter;
 var http = require('http');
@@ -303,6 +304,12 @@ module.exports.isEnabled = function isEnabled() {
               headers: res.headers
             }, resBody);
           } else {
+            var encoding = res.headers['content-encoding'];
+            if (encoding && encoding.match(/gzip|deflate/)) {
+              resBody = zlib.unzipSync(resBody);
+              delete res.headers['content-encoding'];
+            }
+
             fs.writeFileSync(filename,
               replayerUtil.substituteWithOpaqueKeys(resBody.toString()));
 


### PR DESCRIPTION
Hi @aneilbaboo. I noticed that replayer doesn't uncompress the response body when a content-encoding is specified in the response. This causes a couple of issues:
* No content was saved in the fixture file which breaks cache/playback modes, 
* The raw (binary) compressed body is returned in record mode. 

This PR adds support for `gzip` and `deflate` encoded responses, both formats supported by `zlib`. If the `content-encoding` header specifies that the response body is in gzip or format, it unzips the body and deletes the header before writing the fixture. This way the fixture is saved in plain text and the original `content-encoding` header is omitted from the header fixture.