### PR TITLE
Align the option style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The full list of options are as follows:
 - `touchHits`: disable timestamp update of fixture files on a cache hit.
 - `includeHeaderNames`, `headerWhitelist`, `urlBlacklist`, `includeCookieNames`,
   `cookieWhitelist`: detailed in a later section.
-- 'debug': Useful for debugging the requests when there is a cache miss. If
+- `debug`: Useful for debugging the requests when there is a cache miss. If
    fixtures are recorded with debug mode true, replayer will additionally save all
    the incoming requests  as '.request' files. Furthermore, in case of a cache
    miss, during playback, it will attempt to compare the the missing


### PR DESCRIPTION
Just a trivial fix in the document.